### PR TITLE
Add condition for tty detection.

### DIFF
--- a/.liquid.theme
+++ b/.liquid.theme
@@ -24,8 +24,12 @@
 # characters at once.
 # Below is an example of how to fallback to ascii if the term is not unicode capable.
 # Defaults to UTF-8 characters.
+
+showconsolefont 2>/dev/null
+set -l has_console_font $status
+
 set -l mylang (echo $LANG | cut -c 7-)
-if [ $mylang = "utf8" ]
+if [ $mylang = "utf8" ]; and [ $has_console_font -ne 0 ]
     # If charset is UTF-8.
     set -g LP_MARK_BATTERY "⌁"     # in front of the battery charge
     set -g LP_MARK_ADAPTER "⏚"     # displayed when plugged


### PR DESCRIPTION
When a tty is used no buffered terminal is supported. Thus although the
language may be set to utf8 the terminal itself cannot display the
characters. 
Since tty successfully executes `showconsolefont` command and pts does not this seems to be a good hook.
So I took this command to additionally determine if utf8 or characters should be displayed.